### PR TITLE
Add configurable min arb profit floor (default 1 cent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ There's no free lunch from slightly undercutting either. The optimal strategy de
 - Arrival rate `lambda ~ U[0.6, 1.0]` per step
 - Mean order size `~ U[19, 21]` in Y terms
 
-**Arbitrage**: Binary search for the optimal trade that pushes spot price to fair price. Efficient — don't try to extract value from informed flow.
+**Arbitrage**: Binary search for the optimal trade that pushes spot price to fair price. Efficient — don't try to extract value from informed flow. Trades are skipped unless expected arb profit is at least `0.01` Y (1 cent).
 
 **Order routing**: Grid search over split ratio alpha in [0, 1]. The router picks the split that maximizes total output. Small pricing differences can shift large fractions of volume.
 

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -15,6 +15,7 @@ pub const RETAIL_ARRIVAL_RATE: f64 = 0.8; // midpoint of [0.6, 1.0]
 pub const RETAIL_MEAN_SIZE: f64 = 20.0; // midpoint of [19, 21]
 pub const RETAIL_SIZE_SIGMA: f64 = 1.2;
 pub const RETAIL_BUY_PROB: f64 = 0.5;
+pub const MIN_ARB_PROFIT: f64 = 0.01; // 1 cent in quote token (Y)
 
 #[derive(Debug, Clone)]
 pub struct SimulationConfig {
@@ -29,6 +30,7 @@ pub struct SimulationConfig {
     pub retail_mean_size: f64,
     pub retail_size_sigma: f64,
     pub retail_buy_prob: f64,
+    pub min_arb_profit: f64,
     pub seed: u64,
 }
 
@@ -46,6 +48,7 @@ impl Default for SimulationConfig {
             retail_mean_size: RETAIL_MEAN_SIZE,
             retail_size_sigma: RETAIL_SIZE_SIGMA,
             retail_buy_prob: RETAIL_BUY_PROB,
+            min_arb_profit: MIN_ARB_PROFIT,
             seed: 0,
         }
     }
@@ -79,7 +82,8 @@ impl HyperparameterVariance {
         let mut rng = Pcg64::seed_from_u64(seed);
         SimulationConfig {
             gbm_sigma: rng.gen_range(self.gbm_sigma_min..self.gbm_sigma_max),
-            retail_arrival_rate: rng.gen_range(self.retail_arrival_rate_min..self.retail_arrival_rate_max),
+            retail_arrival_rate: rng
+                .gen_range(self.retail_arrival_rate_min..self.retail_arrival_rate_max),
             retail_mean_size: rng.gen_range(self.retail_mean_size_min..self.retail_mean_size_max),
             seed,
             ..base.clone()
@@ -89,5 +93,16 @@ impl HyperparameterVariance {
     pub fn generate_configs(&self, n: u32) -> Vec<SimulationConfig> {
         let base = SimulationConfig::default();
         (0..n).map(|i| self.apply(&base, i as u64)).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SimulationConfig;
+
+    #[test]
+    fn default_min_arb_profit_is_one_cent() {
+        let config = SimulationConfig::default();
+        assert!((config.min_arb_profit - 0.01).abs() < 1e-12);
     }
 }

--- a/crates/sim/src/arbitrageur.rs
+++ b/crates/sim/src/arbitrageur.rs
@@ -7,11 +7,15 @@ pub struct ArbResult {
     pub edge: f64,
 }
 
-pub struct Arbitrageur;
+pub struct Arbitrageur {
+    min_arb_profit: f64,
+}
 
 impl Arbitrageur {
-    pub fn new() -> Self {
-        Self
+    pub fn new(min_arb_profit: f64) -> Self {
+        Self {
+            min_arb_profit: min_arb_profit.max(0.0),
+        }
     }
 
     pub fn execute_arb(&self, amm: &mut BpfAmm, fair_price: f64) -> Option<ArbResult> {
@@ -45,6 +49,16 @@ impl Arbitrageur {
 
         let optimal_y = (lo + hi) / 2.0;
         if optimal_y < 0.001 {
+            return None;
+        }
+
+        let expected_output_x = amm.quote_buy_x(optimal_y);
+        if expected_output_x <= 0.0 {
+            return None;
+        }
+
+        let arb_profit = expected_output_x * fair_price - optimal_y;
+        if arb_profit < self.min_arb_profit {
             return None;
         }
 
@@ -83,6 +97,16 @@ impl Arbitrageur {
             return None;
         }
 
+        let expected_output_y = amm.quote_sell_x(optimal_x);
+        if expected_output_y <= 0.0 {
+            return None;
+        }
+
+        let arb_profit = expected_output_y - optimal_x * fair_price;
+        if arb_profit < self.min_arb_profit {
+            return None;
+        }
+
         let output_y = amm.execute_sell_x(optimal_x);
         if output_y <= 0.0 {
             return None;
@@ -94,5 +118,39 @@ impl Arbitrageur {
             amount_y: output_y,
             edge: optimal_x * fair_price - output_y,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Arbitrageur;
+    use crate::amm::BpfAmm;
+    use prop_amm_shared::normalizer::compute_swap as normalizer_swap;
+
+    fn test_amm() -> BpfAmm {
+        BpfAmm::new_native(normalizer_swap, None, 100.0, 10_000.0, "test".to_string())
+    }
+
+    #[test]
+    fn min_arb_profit_blocks_profitable_trade_when_threshold_is_higher() {
+        let fair_price = 101.0;
+
+        let mut amm_without_floor = test_amm();
+        let no_floor = Arbitrageur::new(0.0);
+        let result = no_floor
+            .execute_arb(&mut amm_without_floor, fair_price)
+            .expect("expected profitable arbitrage");
+        let realized_profit = -result.edge;
+        assert!(
+            realized_profit > 0.0,
+            "arb should produce positive arb profit"
+        );
+
+        let mut amm_with_floor = test_amm();
+        let floor = Arbitrageur::new(realized_profit + 1e-9);
+        assert!(
+            floor.execute_arb(&mut amm_with_floor, fair_price).is_none(),
+            "trade should be skipped when profit ({realized_profit}) is below threshold"
+        );
     }
 }

--- a/crates/sim/src/engine.rs
+++ b/crates/sim/src/engine.rs
@@ -27,7 +27,7 @@ fn run_sim_inner(
         config.retail_buy_prob,
         config.seed.wrapping_add(1),
     );
-    let arb = Arbitrageur::new();
+    let arb = Arbitrageur::new(config.min_arb_profit);
     let router = OrderRouter::new();
 
     let mut submission_edge = 0.0_f64;


### PR DESCRIPTION
## Summary
- add a new simulation config parameter `min_arb_profit`
- default `min_arb_profit` to `0.01` (1 cent)
- skip arb execution when expected arb profit is below the configured threshold
- wire the threshold into the sim engine when constructing the arbitrageur
- document the 1-cent arb floor in the README

## Testing
- cargo check --workspace
- cargo test -p prop-amm-shared
- cargo test -p prop-amm-sim --lib arbitrageur::tests::min_arb_profit_blocks_profitable_trade_when_threshold_is_higher
