### PR TITLE
Pass simulation step into afterSwap payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Return 8 bytes via `sol_set_return_data` — the `output_amount: u64` (1e9 scale
 
 ### afterSwap (Optional)
 
-After each **real trade** (not during quoting), the engine calls your program with tag byte `2`. This lets you update your 1024-byte storage — useful for strategies that adapt over time (dynamic fees, volatility tracking, etc.).
+After each **real trade** (not during quoting), the engine calls your program with tag byte `2`. This lets you update your 1024-byte storage and observe the current simulation step — useful for strategies that adapt over time (dynamic fees, volatility tracking, etc.).
 
 | Offset | Size | Field         | Type   | Description                    |
 |--------|------|---------------|--------|--------------------------------|
@@ -96,7 +96,8 @@ After each **real trade** (not during quoting), the engine calls your program wi
 | 10     | 8    | output_amount | u64    | Output token amount (1e9 scale)|
 | 18     | 8    | reserve_x     | u64    | Post-trade X reserve           |
 | 26     | 8    | reserve_y     | u64    | Post-trade Y reserve           |
-| 34     | 1024 | storage       | [u8]   | Current storage (read/write)   |
+| 34     | 8    | step          | u64    | Current simulation step        |
+| 42     | 1024 | storage       | [u8]   | Current storage (read/write)   |
 
 To persist updated storage, call the `sol_set_storage` syscall with your modified buffer. If you don't call it, storage remains unchanged. The starter program's afterSwap is a no-op — storage is entirely optional.
 

--- a/crates/cli/src/commands/validate.rs
+++ b/crates/cli/src/commands/validate.rs
@@ -154,7 +154,7 @@ pub fn run(so_path: &str) -> anyhow::Result<()> {
         } else {
             (rx.saturating_add(amount), ry.saturating_sub(out))
         };
-        executor.execute_after_swap(side, amount, out, post_rx, post_ry, &mut storage)?;
+        executor.execute_after_swap(side, amount, out, post_rx, post_ry, seed, &mut storage)?;
 
         for side in [0u8, 1u8] {
             check_curve_shape(

--- a/crates/executor/src/native.rs
+++ b/crates/executor/src/native.rs
@@ -35,10 +35,11 @@ impl NativeExecutor {
         output_amount: u64,
         rx: u64,
         ry: u64,
+        step: u64,
         storage: &mut [u8],
     ) {
         if let Some(after_swap) = self.after_swap_fn {
-            let data = encode_after_swap(side, input_amount, output_amount, rx, ry, storage);
+            let data = encode_after_swap(side, input_amount, output_amount, rx, ry, step, storage);
             let copy_len = storage.len().min(STORAGE_SIZE);
             after_swap(&data, &mut storage[..copy_len]);
         }

--- a/crates/executor/src/vm.rs
+++ b/crates/executor/src/vm.rs
@@ -117,22 +117,24 @@ impl BpfExecutor {
         output_amount: u64,
         rx: u64,
         ry: u64,
+        step: u64,
         storage: &mut [u8],
     ) -> Result<(), ExecutorError> {
         self.input_buf.fill(0);
 
         // Write after_swap instruction data:
-        // [tag=2(1)][side(1)][input(8)][output(8)][rx(8)][ry(8)][storage(1024)]
+        // [tag=2(1)][side(1)][input(8)][output(8)][rx(8)][ry(8)][step(8)][storage(1024)]
         self.input_buf[16] = 2; // tag
         self.input_buf[17] = side;
         self.input_buf[18..26].copy_from_slice(&input_amount.to_le_bytes());
         self.input_buf[26..34].copy_from_slice(&output_amount.to_le_bytes());
         self.input_buf[34..42].copy_from_slice(&rx.to_le_bytes());
         self.input_buf[42..50].copy_from_slice(&ry.to_le_bytes());
+        self.input_buf[50..58].copy_from_slice(&step.to_le_bytes());
         let copy_len = storage.len().min(STORAGE_SIZE);
-        self.input_buf[50..50 + copy_len].copy_from_slice(&storage[..copy_len]);
+        self.input_buf[58..58 + copy_len].copy_from_slice(&storage[..copy_len]);
         if copy_len < STORAGE_SIZE {
-            self.input_buf[50 + copy_len..50 + STORAGE_SIZE].fill(0);
+            self.input_buf[58 + copy_len..58 + STORAGE_SIZE].fill(0);
         }
 
         let context = self.run_vm(AFTER_SWAP_SIZE)?;

--- a/crates/sim/src/amm.rs
+++ b/crates/sim/src/amm.rs
@@ -15,6 +15,7 @@ pub struct BpfAmm {
     pub reserve_y: f64,
     pub name: String,
     storage: Vec<u8>,
+    current_step: u64,
 }
 
 impl BpfAmm {
@@ -25,6 +26,7 @@ impl BpfAmm {
             reserve_y,
             name,
             storage: vec![0u8; STORAGE_SIZE],
+            current_step: 0,
         }
     }
 
@@ -41,6 +43,7 @@ impl BpfAmm {
             reserve_y,
             name,
             storage: vec![0u8; STORAGE_SIZE],
+            current_step: 0,
         }
     }
 
@@ -71,6 +74,7 @@ impl BpfAmm {
                     output_amount,
                     rx,
                     ry,
+                    self.current_step,
                     &mut self.storage,
                 );
             }
@@ -81,10 +85,15 @@ impl BpfAmm {
                     output_amount,
                     rx,
                     ry,
+                    self.current_step,
                     &mut self.storage,
                 );
             }
         }
+    }
+
+    pub fn set_current_step(&mut self, step: u64) {
+        self.current_step = step;
     }
 
     #[inline]
@@ -213,5 +222,6 @@ impl BpfAmm {
         self.reserve_x = reserve_x;
         self.reserve_y = reserve_y;
         self.storage.fill(0);
+        self.current_step = 0;
     }
 }

--- a/crates/sim/src/engine.rs
+++ b/crates/sim/src/engine.rs
@@ -37,7 +37,9 @@ fn run_sim_inner(
 
     let mut submission_edge = 0.0_f64;
 
-    for _ in 0..config.n_steps {
+    for step in 0..config.n_steps {
+        amm_sub.set_current_step(step as u64);
+        amm_norm.set_current_step(step as u64);
         let fair_price = price.step();
 
         if let Some(result) = arb.execute_arb(&mut amm_sub, fair_price) {

--- a/crates/sim/tests/integration.rs
+++ b/crates/sim/tests/integration.rs
@@ -200,7 +200,7 @@ fn test_after_swap_noop() {
     let mut exec = BpfExecutor::new(program);
     let mut storage = [0u8; STORAGE_SIZE];
 
-    exec.execute_after_swap(0, 1000, 500, 2000, 3000, &mut storage)
+    exec.execute_after_swap(0, 1000, 500, 2000, 3000, 0, &mut storage)
         .unwrap();
     // Storage should remain unchanged (starter is a no-op)
     assert_eq!(storage, [0u8; STORAGE_SIZE]);


### PR DESCRIPTION
## Summary
- add `step: u64` to the `afterSwap` payload layout in shared instruction encoding/decoding
- thread `step` through native and BPF executors and include it in the after-swap instruction buffer
- track current simulation step in `BpfAmm` and set it per loop iteration in the engine before trades
- update validation/integration call sites and README docs for the new payload offsets

## Testing
- `cargo test --workspace --lib`
- `cargo test` *(integration suite fails in this environment due existing normalizer ELF load error: `ElfLoad("ELF error: Offset or value is out of bounds")`)*
