### PR TITLE
Add normalizer fee, liquidity, and wider vol hyperparameters

### DIFF
--- a/crates/shared/src/normalizer.rs
+++ b/crates/shared/src/normalizer.rs
@@ -20,16 +20,23 @@ pub fn compute_swap(data: &[u8]) -> u64 {
         return 0;
     }
 
+    let fee_bps = if data.len() >= 27 {
+        let raw = u16::from_le_bytes([data[25], data[26]]);
+        if raw == 0 { 30u128 } else { raw as u128 }
+    } else {
+        30u128
+    };
+
     let k = reserve_x * reserve_y;
 
     match side {
         0 => {
-            let net = input_amount * 997 / 1000;
+            let net = input_amount * (10000 - fee_bps) / 10000;
             let new_ry = reserve_y + net;
             reserve_x.saturating_sub((k + new_ry - 1) / new_ry) as u64
         }
         1 => {
-            let net = input_amount * 997 / 1000;
+            let net = input_amount * (10000 - fee_bps) / 10000;
             let new_rx = reserve_x + net;
             reserve_y.saturating_sub((k + new_rx - 1) / new_rx) as u64
         }

--- a/crates/sim/src/amm.rs
+++ b/crates/sim/src/amm.rs
@@ -209,6 +209,11 @@ impl BpfAmm {
         }
     }
 
+    pub fn set_initial_storage(&mut self, bytes: &[u8]) {
+        let n = bytes.len().min(self.storage.len());
+        self.storage[..n].copy_from_slice(&bytes[..n]);
+    }
+
     pub fn reset(&mut self, reserve_x: f64, reserve_y: f64) {
         self.reserve_x = reserve_x;
         self.reserve_y = reserve_y;

--- a/crates/sim/src/engine.rs
+++ b/crates/sim/src/engine.rs
@@ -79,12 +79,15 @@ pub fn run_simulation(
         config.initial_y,
         "submission".to_string(),
     );
-    let amm_norm = BpfAmm::new(
+    let norm_x = config.initial_x * config.norm_liquidity_mult;
+    let norm_y = config.initial_y * config.norm_liquidity_mult;
+    let mut amm_norm = BpfAmm::new(
         normalizer_program,
-        config.initial_x,
-        config.initial_y,
+        norm_x,
+        norm_y,
         "normalizer".to_string(),
     );
+    amm_norm.set_initial_storage(&config.norm_fee_bps.to_le_bytes());
     run_sim_inner(amm_sub, amm_norm, config)
 }
 
@@ -103,13 +106,16 @@ pub fn run_simulation_native(
         config.initial_y,
         "submission".to_string(),
     );
-    let amm_norm = BpfAmm::new_native(
+    let norm_x = config.initial_x * config.norm_liquidity_mult;
+    let norm_y = config.initial_y * config.norm_liquidity_mult;
+    let mut amm_norm = BpfAmm::new_native(
         normalizer_fn,
         normalizer_after_swap,
-        config.initial_x,
-        config.initial_y,
+        norm_x,
+        norm_y,
         "normalizer".to_string(),
     );
+    amm_norm.set_initial_storage(&config.norm_fee_bps.to_le_bytes());
     run_sim_inner(amm_sub, amm_norm, config)
 }
 
@@ -126,12 +132,15 @@ pub fn run_simulation_mixed(
         config.initial_y,
         "submission".to_string(),
     );
-    let amm_norm = BpfAmm::new_native(
+    let norm_x = config.initial_x * config.norm_liquidity_mult;
+    let norm_y = config.initial_y * config.norm_liquidity_mult;
+    let mut amm_norm = BpfAmm::new_native(
         normalizer_fn,
         normalizer_after_swap,
-        config.initial_x,
-        config.initial_y,
+        norm_x,
+        norm_y,
         "normalizer".to_string(),
     );
+    amm_norm.set_initial_storage(&config.norm_fee_bps.to_le_bytes());
     run_sim_inner(amm_sub, amm_norm, config)
 }


### PR DESCRIPTION
## Summary
- Add `norm_fee_bps` (10-100bps) and `norm_liquidity_mult` (0.5-2.0x) per-simulation hyperparameters to vary normalizer competitiveness
- Widen `gbm_sigma` range from [0.000882, 0.001008] to [0.0005, 0.002] (~4x wider) for broader volatility regimes
- Native normalizer reads fee from storage bytes (zero-initialized defaults to 30bps for backwards compatibility)

## Test plan
- [x] `cargo build` compiles cleanly
- [x] All 14 existing integration tests pass unchanged (default config has `norm_fee_bps: 30, norm_liquidity_mult: 1.0`)
- [x] New test: fee-from-storage produces correct outputs at 10/30/100 bps
- [x] New test: different `norm_liquidity_mult` values produce different simulation edges
- [x] New test: `HyperparameterVariance::generate_configs()` produces values in expected ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)