### PR TITLE
Rebalance sampled simulator ranges with rounded constrained defaults

### DIFF
--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -9,10 +9,10 @@ pub const INITIAL_PRICE: f64 = 100.0;
 pub const INITIAL_X: f64 = 100.0;
 pub const INITIAL_Y: f64 = 10_000.0;
 pub const GBM_MU: f64 = 0.0;
-pub const GBM_SIGMA: f64 = 0.000945; // midpoint of [0.000882, 0.001008]
+pub const GBM_SIGMA: f64 = 0.000945; // baseline point estimate
 pub const GBM_DT: f64 = 1.0;
-pub const RETAIL_ARRIVAL_RATE: f64 = 0.8; // midpoint of [0.6, 1.0]
-pub const RETAIL_MEAN_SIZE: f64 = 20.0; // midpoint of [19, 21]
+pub const RETAIL_ARRIVAL_RATE: f64 = 0.8; // midpoint of [0.4, 1.2]
+pub const RETAIL_MEAN_SIZE: f64 = 20.0; // midpoint of [12, 28]
 pub const RETAIL_SIZE_SIGMA: f64 = 1.2;
 pub const RETAIL_BUY_PROB: f64 = 0.5;
 pub const MIN_ARB_PROFIT: f64 = 0.01; // 1 cent in quote token (Y)
@@ -75,15 +75,15 @@ pub struct HyperparameterVariance {
 impl Default for HyperparameterVariance {
     fn default() -> Self {
         Self {
-            gbm_sigma_min: 0.0005,
-            gbm_sigma_max: 0.002,
-            retail_arrival_rate_min: 0.6,
-            retail_arrival_rate_max: 1.0,
-            retail_mean_size_min: 19.0,
-            retail_mean_size_max: 21.0,
-            norm_fee_bps_min: 10,
-            norm_fee_bps_max: 100,
-            norm_liquidity_mult_min: 0.5,
+            gbm_sigma_min: 0.0001,
+            gbm_sigma_max: 0.007,
+            retail_arrival_rate_min: 0.4,
+            retail_arrival_rate_max: 1.2,
+            retail_mean_size_min: 12.0,
+            retail_mean_size_max: 28.0,
+            norm_fee_bps_min: 30,
+            norm_fee_bps_max: 80,
+            norm_liquidity_mult_min: 0.4,
             norm_liquidity_mult_max: 2.0,
         }
     }

--- a/crates/sim/tests/integration.rs
+++ b/crates/sim/tests/integration.rs
@@ -320,19 +320,24 @@ fn test_hyperparameter_variance_generates_varied_configs() {
 
     let sigma_min = configs.iter().map(|c| c.gbm_sigma).fold(f64::INFINITY, f64::min);
     let sigma_max = configs.iter().map(|c| c.gbm_sigma).fold(f64::NEG_INFINITY, f64::max);
-    assert!(sigma_min >= 0.0005, "sigma_min {} below range", sigma_min);
-    assert!(sigma_max <= 0.002, "sigma_max {} above range", sigma_max);
-    assert!(sigma_max - sigma_min > 0.001, "sigma range too narrow: [{}, {}]", sigma_min, sigma_max);
+    assert!(sigma_min >= 0.0001, "sigma_min {} below range", sigma_min);
+    assert!(sigma_max <= 0.007, "sigma_max {} above range", sigma_max);
+    assert!(
+        sigma_max - sigma_min > 0.003,
+        "sigma range too narrow: [{}, {}]",
+        sigma_min,
+        sigma_max
+    );
 
     let fee_min = configs.iter().map(|c| c.norm_fee_bps).min().unwrap();
     let fee_max = configs.iter().map(|c| c.norm_fee_bps).max().unwrap();
-    assert!(fee_min >= 10, "fee_min {} below range", fee_min);
-    assert!(fee_max <= 100, "fee_max {} above range", fee_max);
+    assert!(fee_min >= 30, "fee_min {} below range", fee_min);
+    assert!(fee_max <= 80, "fee_max {} above range", fee_max);
     assert!(fee_max - fee_min > 30, "fee range too narrow: [{}, {}]", fee_min, fee_max);
 
     let liq_min = configs.iter().map(|c| c.norm_liquidity_mult).fold(f64::INFINITY, f64::min);
     let liq_max = configs.iter().map(|c| c.norm_liquidity_mult).fold(f64::NEG_INFINITY, f64::max);
-    assert!(liq_min >= 0.5, "liq_min {} below range", liq_min);
+    assert!(liq_min >= 0.4, "liq_min {} below range", liq_min);
     assert!(liq_max <= 2.0, "liq_max {} above range", liq_max);
     assert!(liq_max - liq_min > 0.5, "liq range too narrow: [{}, {}]", liq_min, liq_max);
 }


### PR DESCRIPTION
## Summary
This PR updates the simulator's sampled hyperparameter ranges to a rounded, constrained set that better balances how much each parameter contributes to score variance.

It also keeps the two requested constraints:
- `norm_fee_bps` range includes `30`
- `norm_liquidity_mult` range includes `1.0`

## Parameter Changes
Old (`main` before this PR) -> New (this PR):

- `gbm_sigma`: `0.0005..0.002` -> `0.0001..0.0070`
- `retail_arrival_rate`: `0.6..1.0` -> `0.4..1.2`
- `retail_mean_size`: `19..21` -> `12..28`
- `norm_fee_bps`: `10..100` -> `30..80`
- `norm_liquidity_mult`: `0.5..2.0` -> `0.4..2.0`

## Why This Is Better
The previous ranges were heavily dominated by normalizer fee variance, with volatility and retail size contributing very little to edge variation at the best static-fee solution.

Using a 1000-sim / 10k-step evaluation of static-fee CPMM:

- **Before (old ranges, best static fee = 60 bps)**
  - normalized contribution split (`sigma, arrival, size, norm_fee, norm_liq`):
  - `[0.1, 9.2, 0.5, 70.3, 19.9]`
  - balance RMS to 20/20/20/20/20 target: **26.16**

- **After (new ranges in this PR, best static fee = 60 bps)**
  - normalized contribution split (`sigma, arrival, size, norm_fee, norm_liq`):
  - `[23.4, 22.2, 18.9, 18.7, 16.9]`
  - balance RMS to 20/20/20/20/20 target: **2.40**

This materially improves variance balance across all five sampled dimensions while satisfying the requested inclusion constraints and keeping ranges rounded/readable.

## Additional Changes
- Updated README market-parameter documentation to match actual sampled ranges.
- Updated integration test expectations for `HyperparameterVariance::default()`.

## Validation
- `cargo test -p prop-amm-shared`
- `cargo test -p prop-amm-sim --test integration test_hyperparameter_variance_generates_varied_configs`
