### PR TITLE
Fix fresh-clone quick-start onboarding blockers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
 exclude = [
     "programs/normalizer",
     "programs/starter",
+    ".build",
 ]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Your program runs inside a simulation against a benchmark AMM. Retail traders ar
 For local development, use the CLI:
 
 ```bash
+# Install the CLI once (from this repo)
+cargo install --path crates/cli
+
 # Copy the starter template
 cp programs/starter/src/lib.rs my_amm.rs
 
@@ -21,6 +24,9 @@ edit my_amm.rs
 
 # Run 1000 simulations locally (~5s on Apple M3 Pro)
 prop-amm run my_amm.rs
+
+# Or run without installing the binary globally
+cargo run -p prop-amm -- run my_amm.rs
 ```
 
 The CLI compiles your source file and runs it natively — no toolchain setup required beyond Rust.


### PR DESCRIPTION
## Summary
Fixes three issues that block first-time users following the README quick-start flow.

## Issues fixed
- `prop-amm` command is used before installation is documented.
- Fresh clone compilation failed because `crates/sim` did a compile-time `include_bytes!` of `programs/normalizer/target/deploy/normalizer.so`.
- CLI temporary build crate `.build/` conflicted with workspace membership.

## Changes
- Add CLI install and no-install fallback command to quick-start docs.
- Exclude `.build` from workspace in root `Cargo.toml`.
- Change benchmark normalizer `.so` loading from compile-time include to runtime load with a clear skip message when artifact is missing.

## Verification
- `cargo run -p prop-amm -- run starter.rs --simulations 5`
- `cargo run -p prop-amm -- validate starter.rs`
- `cargo test --workspace`
- `cargo install --path crates/cli --root /tmp/prop-amm-install-test --force`
