### PR TITLE
Require wincode for challenge payload decoding

### DIFF
--- a/crates/cli/src/commands/compile.rs
+++ b/crates/cli/src/commands/compile.rs
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 pinocchio = "0.7"
+wincode = { version = "0.4", default-features = false, features = ["derive"] }
 
 [features]
 no-entrypoint = []
@@ -23,7 +24,11 @@ pub fn ensure_build_dir() -> anyhow::Result<PathBuf> {
     std::fs::create_dir_all(build_dir.join("src"))?;
 
     let cargo_path = build_dir.join("Cargo.toml");
-    if !cargo_path.exists() {
+    let should_write = match std::fs::read_to_string(&cargo_path) {
+        Ok(existing) => existing != CARGO_TOML,
+        Err(_) => true,
+    };
+    if should_write {
         std::fs::write(&cargo_path, CARGO_TOML)?;
     }
 

--- a/programs/starter/Cargo.lock
+++ b/programs/starter/Cargo.lock
@@ -3,14 +3,154 @@
 version = 4
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pinocchio"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a8a77bf74e1c4050a2bad53648acfcfbf22b1806473f9c9334a58ef3b38ec4"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "starter"
 version = "0.1.0"
 dependencies = [
  "pinocchio",
+ "wincode",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "wincode"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "466e67917609b2d40a838a5b972d1a6237c9749600cb8de8f65559b90d48485b"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror",
+ "wincode-derive",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26a7a568eda854acc9945ed136a9d50b8c6d31911584624958808ae96eee3912"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/programs/starter/Cargo.toml
+++ b/programs/starter/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 pinocchio = "0.7"
+wincode = { version = "0.4", default-features = false, features = ["derive"] }
 
 [features]
 no-entrypoint = []

--- a/programs/starter/src/lib.rs
+++ b/programs/starter/src/lib.rs
@@ -3,6 +3,16 @@ use pinocchio::{account_info::AccountInfo, entrypoint, pubkey::Pubkey, ProgramRe
 const NAME: &str = "My Strategy";
 const FEE_NUMERATOR: u128 = 950;
 const FEE_DENOMINATOR: u128 = 1000;
+const STORAGE_SIZE: usize = 1024;
+
+#[derive(wincode::SchemaRead)]
+struct ComputeSwapInstruction {
+    side: u8,
+    input_amount: u64,
+    reserve_x: u64,
+    reserve_y: u64,
+    _storage: [u8; STORAGE_SIZE],
+}
 
 #[cfg(not(feature = "no-entrypoint"))]
 entrypoint!(process_instruction);
@@ -35,20 +45,15 @@ pub fn process_instruction(
 }
 
 pub fn compute_swap(data: &[u8]) -> u64 {
-    if data.len() < 25 {
-        return 0;
-    }
+    let decoded: ComputeSwapInstruction = match wincode::deserialize(data) {
+        Ok(decoded) => decoded,
+        Err(_) => return 0,
+    };
 
-    let side = data[0];
-    let input_amount = u64::from_le_bytes([
-        data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8],
-    ]) as u128;
-    let reserve_x = u64::from_le_bytes([
-        data[9], data[10], data[11], data[12], data[13], data[14], data[15], data[16],
-    ]) as u128;
-    let reserve_y = u64::from_le_bytes([
-        data[17], data[18], data[19], data[20], data[21], data[22], data[23], data[24],
-    ]) as u128;
+    let side = decoded.side;
+    let input_amount = decoded.input_amount as u128;
+    let reserve_x = decoded.reserve_x as u128;
+    let reserve_y = decoded.reserve_y as u128;
 
     if reserve_x == 0 || reserve_y == 0 {
         return 0;
@@ -83,6 +88,11 @@ pub unsafe extern "C" fn compute_swap_ffi(data: *const u8, len: usize) -> u64 {
 /// FFI export for after_swap hook (no-op for starter)
 #[cfg(not(target_os = "solana"))]
 #[no_mangle]
-pub unsafe extern "C" fn after_swap_ffi(_data: *const u8, _data_len: usize, _storage: *mut u8, _storage_len: usize) {
+pub unsafe extern "C" fn after_swap_ffi(
+    _data: *const u8,
+    _data_len: usize,
+    _storage: *mut u8,
+    _storage_len: usize,
+) {
     // No-op: starter doesn't use storage
 }

--- a/starter.rs
+++ b/starter.rs
@@ -3,6 +3,16 @@ use pinocchio::{account_info::AccountInfo, entrypoint, pubkey::Pubkey, ProgramRe
 const NAME: &str = "My Strategy";
 const FEE_NUMERATOR: u128 = 950;
 const FEE_DENOMINATOR: u128 = 1000;
+const STORAGE_SIZE: usize = 1024;
+
+#[derive(wincode::SchemaRead)]
+struct ComputeSwapInstruction {
+    side: u8,
+    input_amount: u64,
+    reserve_x: u64,
+    reserve_y: u64,
+    _storage: [u8; STORAGE_SIZE],
+}
 
 #[cfg(not(feature = "no-entrypoint"))]
 entrypoint!(process_instruction);
@@ -35,20 +45,15 @@ pub fn process_instruction(
 }
 
 pub fn compute_swap(data: &[u8]) -> u64 {
-    if data.len() < 25 {
-        return 0;
-    }
+    let decoded: ComputeSwapInstruction = match wincode::deserialize(data) {
+        Ok(decoded) => decoded,
+        Err(_) => return 0,
+    };
 
-    let side = data[0];
-    let input_amount = u64::from_le_bytes([
-        data[1], data[2], data[3], data[4], data[5], data[6], data[7], data[8],
-    ]) as u128;
-    let reserve_x = u64::from_le_bytes([
-        data[9], data[10], data[11], data[12], data[13], data[14], data[15], data[16],
-    ]) as u128;
-    let reserve_y = u64::from_le_bytes([
-        data[17], data[18], data[19], data[20], data[21], data[22], data[23], data[24],
-    ]) as u128;
+    let side = decoded.side;
+    let input_amount = decoded.input_amount as u128;
+    let reserve_x = decoded.reserve_x as u128;
+    let reserve_y = decoded.reserve_y as u128;
 
     if reserve_x == 0 || reserve_y == 0 {
         return 0;


### PR DESCRIPTION
## Summary
- add `wincode` as an allowed challenge dependency and document it in README guidelines
- update starter templates to decode swap instruction payloads via `wincode::deserialize`
- update CLI build scaffold to include `wincode` and refresh stale `.build/Cargo.toml` when needed

## Validation
- `cargo check`
- `cargo check --manifest-path programs/starter/Cargo.toml`
- `cargo run -p prop-amm -- validate starter.rs`
