### PR TITLE
Widen curve-shape concavity tolerance

### DIFF
--- a/crates/sim/src/arbitrageur.rs
+++ b/crates/sim/src/arbitrageur.rs
@@ -366,7 +366,7 @@ impl Arbitrageur {
             } else {
                 slope
             };
-            let slope_rounding_tol = ref_slope * 5e-4 + 8.0 / din;
+            let slope_rounding_tol = ref_slope * 1e-3 + 12.0 / din;
             if slope > prev_slope + slope_rounding_tol {
                 return false;
             }

--- a/crates/sim/src/router.rs
+++ b/crates/sim/src/router.rs
@@ -379,7 +379,7 @@ impl OrderRouter {
             } else {
                 slope
             };
-            let slope_rounding_tol = ref_slope * 5e-4 + 8.0 / din;
+            let slope_rounding_tol = ref_slope * 1e-3 + 12.0 / din;
             if slope > prev_slope + slope_rounding_tol {
                 return false;
             }


### PR DESCRIPTION
## Summary
- Bumps slope-relative tolerance from `5e-4` to `1e-3` (0.05% → 0.1%)
- Bumps input-relative tolerance from `8.0/din` to `12.0/din`
- Applied identically to both arbitrageur and router `is_curve_shape_valid()`

Reduces false rejections on legitimate BPF programs with wide fee schedules while still preventing genuinely non-concave curves that could exploit the golden-section search convergence (see discussion below).

### Why not relax all the way to monotonic?

A non-concave curve can cause the arbitrageur's golden-section search to converge to a local profit maximum instead of the global one, making the AMM lose less to arb than it should. The router is less affected because its split objective is dampened by the always-concave normalizer curve. This asymmetry means dropping concavity entirely would give submitters an exploitable (if noisy) scoring advantage.

Widening the tolerance is the safer lever — it accommodates BPF integer rounding artifacts without opening the door to deliberately crafted S-curves.

## Test plan
- [x] `cargo test --workspace` passes
- [ ] Run `prop-amm validate` against starter and solution programs to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)