### PR TITLE
Remove curve shape concavity check

### DIFF
--- a/crates/sim/src/arbitrageur.rs
+++ b/crates/sim/src/arbitrageur.rs
@@ -1,5 +1,5 @@
 use crate::amm::BpfAmm;
-use prop_amm_shared::nano::{f64_to_nano, NANO_SCALE_F64};
+use prop_amm_shared::nano::NANO_SCALE_F64;
 use rand::SeedableRng;
 use rand_distr::{Distribution, LogNormal};
 use rand_pcg::Pcg64;
@@ -62,18 +62,14 @@ impl Arbitrageur {
 
     fn arb_buy_x(&mut self, amm: &mut BpfAmm, fair_price: f64) -> Option<ArbResult> {
         let start_y = self.sample_retail_size_y().min(MAX_INPUT_AMOUNT);
-        let mut sampled_curve = Vec::with_capacity(BRACKET_MAX_STEPS + GOLDEN_MAX_ITERS + 8);
         let (lo, hi) = Self::bracket_maximum(start_y, MAX_INPUT_AMOUNT, |input_y| {
             let output_x = amm.quote_buy_x(input_y);
-            sampled_curve.push((input_y, output_x));
             output_x * fair_price - input_y
         });
         let (optimal_y, _) = Self::golden_section_max(lo, hi, |input_y| {
             let output_x = amm.quote_buy_x(input_y);
-            sampled_curve.push((input_y, output_x));
             output_x * fair_price - input_y
         });
-        Self::enforce_submission_curve_shape(amm, &sampled_curve, amm.reserve_x, "buy");
 
         if optimal_y < MIN_INPUT {
             return None;
@@ -106,18 +102,14 @@ impl Arbitrageur {
         let start_x = (self.sample_retail_size_y() / fair_price.max(1e-9))
             .max(MIN_INPUT)
             .min(MAX_INPUT_AMOUNT);
-        let mut sampled_curve = Vec::with_capacity(BRACKET_MAX_STEPS + GOLDEN_MAX_ITERS + 8);
         let (lo, hi) = Self::bracket_maximum(start_x, MAX_INPUT_AMOUNT, |input_x| {
             let output_y = amm.quote_sell_x(input_x);
-            sampled_curve.push((input_x, output_y));
             output_y - input_x * fair_price
         });
         let (optimal_x, _) = Self::golden_section_max(lo, hi, |input_x| {
             let output_y = amm.quote_sell_x(input_x);
-            sampled_curve.push((input_x, output_y));
             output_y - input_x * fair_price
         });
-        Self::enforce_submission_curve_shape(amm, &sampled_curve, amm.reserve_y, "sell");
 
         if optimal_x < MIN_INPUT {
             return None;
@@ -265,116 +257,6 @@ impl Arbitrageur {
         }
     }
 
-    fn enforce_submission_curve_shape(
-        amm: &BpfAmm,
-        points: &[(f64, f64)],
-        max_output: f64,
-        side_label: &str,
-    ) {
-        if amm.name != "submission" {
-            return;
-        }
-        if !Self::is_curve_shape_valid(points, max_output) {
-            panic!(
-                "submission curve shape violation detected during arbitrage {} search",
-                side_label
-            );
-        }
-    }
-
-    fn is_curve_shape_valid(points: &[(f64, f64)], max_output: f64) -> bool {
-        const MIN_INPUT_NANO: u64 = 1_000_000; // 0.001 units
-
-        let max_output_nano = f64_to_nano(max_output);
-        if max_output_nano == 0 {
-            return false;
-        }
-        if points.is_empty() {
-            return true;
-        }
-
-        // Validate in nano-space to avoid floating-point artifacts.
-        let mut sorted: Vec<(u64, u64)> = points
-            .iter()
-            .filter_map(|(input, output)| {
-                if !input.is_finite() || !output.is_finite() || *input < 0.0 {
-                    return None;
-                }
-                let input_nano = f64_to_nano(*input);
-                let output_nano = f64_to_nano(*output);
-                if input_nano < MIN_INPUT_NANO
-                    || output_nano == 0
-                    || output_nano >= max_output_nano
-                {
-                    return None;
-                }
-                Some((input_nano, output_nano))
-            })
-            .collect();
-        if sorted.len() < 3 {
-            return true;
-        }
-        sorted.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
-
-        // Collapse duplicate inputs to a single best-observed output.
-        let mut collapsed: Vec<(u64, u64)> = Vec::with_capacity(sorted.len());
-        for (input_nano, output_nano) in sorted {
-            if let Some((last_in, last_out)) = collapsed.last_mut() {
-                if *last_in == input_nano {
-                    *last_out = (*last_out).max(output_nano);
-                    continue;
-                }
-            }
-            collapsed.push((input_nano, output_nano));
-        }
-
-        if collapsed.len() < 3 {
-            return true;
-        }
-
-        const MIN_DIN: u64 = 100_000;
-
-        let mut landmarks: Vec<(u64, u64)> = Vec::new();
-        for &(in_n, out_n) in &collapsed {
-            if let Some(&(last_in, _)) = landmarks.last() {
-                if in_n - last_in < MIN_DIN {
-                    continue;
-                }
-            }
-            landmarks.push((in_n, out_n));
-        }
-
-        if landmarks.len() < 3 {
-            return true;
-        }
-
-        let mut prev_slope = f64::INFINITY;
-        for window in landmarks.windows(2) {
-            let (in_a, out_a) = window[0];
-            let (in_b, out_b) = window[1];
-            if out_b + 1 < out_a {
-                return false;
-            }
-            let din = (in_b - in_a) as f64;
-            let dout = out_b.saturating_sub(out_a) as f64;
-            let slope = dout / din;
-            if slope < 0.0 {
-                return false;
-            }
-            let ref_slope = if prev_slope.is_finite() {
-                prev_slope.max(slope)
-            } else {
-                slope
-            };
-            let slope_rounding_tol = ref_slope * 1e-3 + 12.0 / din;
-            if slope > prev_slope + slope_rounding_tol {
-                return false;
-            }
-            prev_slope = slope;
-        }
-
-        true
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Remove the concavity/convexity validation from the router, arbitrageur, and CLI validate command
- The check was causing false positives due to BPF integer rounding artifacts, requiring repeated tolerance relaxations
- Also removes the now-unused `sampled_curve` collection in the arbitrageur and `sampled` field in the router's split search

## Test plan
- [x] `cargo check` passes
- [x] All existing tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)