### PR TITLE
Add sol_memcpy_ and sol_memset_ syscalls to BPF loader

### DIFF
--- a/crates/executor/src/loader.rs
+++ b/crates/executor/src/loader.rs
@@ -8,7 +8,8 @@ use solana_rbpf::{
 };
 
 use crate::syscalls::{
-    SyscallAbort, SyscallContext, SyscallLog, SyscallSetReturnData, SyscallSetStorage,
+    SyscallAbort, SyscallContext, SyscallLog, SyscallMemcpy, SyscallMemset,
+    SyscallSetReturnData, SyscallSetStorage,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -49,6 +50,12 @@ impl BpfProgram {
             .map_err(|e| ExecutorError::ElfLoad(e.to_string()))?;
         function_registry
             .register_function_hashed(*b"sol_set_storage", SyscallSetStorage::vm)
+            .map_err(|e| ExecutorError::ElfLoad(e.to_string()))?;
+        function_registry
+            .register_function_hashed(*b"sol_memcpy_", SyscallMemcpy::vm)
+            .map_err(|e| ExecutorError::ElfLoad(e.to_string()))?;
+        function_registry
+            .register_function_hashed(*b"sol_memset_", SyscallMemset::vm)
             .map_err(|e| ExecutorError::ElfLoad(e.to_string()))?;
 
         let loader = Arc::new(BuiltinProgram::new_loader(

--- a/crates/executor/src/syscalls.rs
+++ b/crates/executor/src/syscalls.rs
@@ -111,6 +111,63 @@ declare_builtin_function!(
 );
 
 declare_builtin_function!(
+    /// Memory copy: sol_memcpy_(dst, src, n)
+    SyscallMemcpy,
+    fn rust(
+        _context_object: &mut SyscallContext,
+        dst_addr: u64,
+        src_addr: u64,
+        n: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Box<dyn std::error::Error>> {
+        if n == 0 {
+            return Ok(0);
+        }
+        let src_host: Result<u64, EbpfError> =
+            memory_mapping.map(AccessType::Load, src_addr, n).into();
+        let src_host = src_host?;
+        let dst_host: Result<u64, EbpfError> =
+            memory_mapping.map(AccessType::Store, dst_addr, n).into();
+        let dst_host = dst_host?;
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                src_host as *const u8,
+                dst_host as *mut u8,
+                n as usize,
+            );
+        }
+        Ok(0)
+    }
+);
+
+declare_builtin_function!(
+    /// Memory set: sol_memset_(dst, val, n)
+    SyscallMemset,
+    fn rust(
+        _context_object: &mut SyscallContext,
+        dst_addr: u64,
+        val: u64,
+        n: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Box<dyn std::error::Error>> {
+        if n == 0 {
+            return Ok(0);
+        }
+        let dst_host: Result<u64, EbpfError> =
+            memory_mapping.map(AccessType::Store, dst_addr, n).into();
+        let dst_host = dst_host?;
+        unsafe {
+            std::ptr::write_bytes(dst_host as *mut u8, val as u8, n as usize);
+        }
+        Ok(0)
+    }
+);
+
+declare_builtin_function!(
     /// BPF program calls this to write updated storage after afterSwap.
     /// arg1 = vm address of data, arg2 = length (must be <= STORAGE_SIZE)
     SyscallSetStorage,


### PR DESCRIPTION
## Summary
- BPF programs that use bulk memory operations (array zero-init, `copy_from_slice` on large buffers) compile to `sol_memcpy_`/`sol_memset_` syscall imports
- These syscalls were not registered in the BPF loader, causing any `afterSwap` implementation using array ops to silently fail with "unsupported BPF instruction"
- This made BPF mode effectively stateless — storage was never persisted, causing BPF and native sim results to diverge

## Test plan
- [x] Verified BPF and native produce identical results (468.71 avg edge) on 50 sims with same seeds
- [x] Confirmed `sol_memcpy_` and `sol_memset_` appear as `*UND*` imports in BPF ELFs that use array operations
- [x] Before fix: every `afterSwap` BPF call failed with "unsupported BPF instruction" (error was swallowed by `let _ =`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)