### PR TITLE
Executor: add sol_memmove_/sol_memcmp_ and harden sol_memcpy_

### DIFF
--- a/crates/executor/src/loader.rs
+++ b/crates/executor/src/loader.rs
@@ -8,8 +8,8 @@ use solana_rbpf::{
 };
 
 use crate::syscalls::{
-    SyscallAbort, SyscallContext, SyscallLog, SyscallMemcpy, SyscallMemset,
-    SyscallSetReturnData, SyscallSetStorage,
+    SyscallAbort, SyscallContext, SyscallLog, SyscallMemcmp, SyscallMemcpy, SyscallMemmove,
+    SyscallMemset, SyscallSetReturnData, SyscallSetStorage,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -53,6 +53,12 @@ impl BpfProgram {
             .map_err(|e| ExecutorError::ElfLoad(e.to_string()))?;
         function_registry
             .register_function_hashed(*b"sol_memcpy_", SyscallMemcpy::vm)
+            .map_err(|e| ExecutorError::ElfLoad(e.to_string()))?;
+        function_registry
+            .register_function_hashed(*b"sol_memmove_", SyscallMemmove::vm)
+            .map_err(|e| ExecutorError::ElfLoad(e.to_string()))?;
+        function_registry
+            .register_function_hashed(*b"sol_memcmp_", SyscallMemcmp::vm)
             .map_err(|e| ExecutorError::ElfLoad(e.to_string()))?;
         function_registry
             .register_function_hashed(*b"sol_memset_", SyscallMemset::vm)


### PR DESCRIPTION
## Summary
- register `sol_memmove_` and `sol_memcmp_` in the BPF loader
- implement `SyscallMemmove` and `SyscallMemcmp` in executor syscalls
- harden `SyscallMemcpy` to use overlap-safe copy (`ptr::copy`) to avoid host UB on overlapping guest ranges

## Why
- Some SBF programs/libraries may emit `sol_memmove_`/`sol_memcmp_`; unresolved helpers cause runtime `unsupported BPF instruction` failures.
- Current `sol_memcpy_` implementation used `copy_nonoverlapping`, which is UB if guest passes overlapping ranges.

## Security / Risk
- No new persistence permissions are introduced.
- Memory access still goes through `memory_mapping.map(...)` bounds checks.
- `memcpy` hardening reduces host-side safety risk under malformed/malicious guest inputs.

## Validation
- `cargo test -p prop-amm-executor`
- `cargo run -p prop-amm -- validate /tmp/lib_force_storage.rs`
- `cargo run -p prop-amm -- validate /tmp/memmove_memcmp_probe.rs`
