### PR TITLE
Add NAME requirement and tag 3 to starters and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ To persist updated storage, call the `sol_set_storage` syscall with your modifie
 
 | Requirement   | Description                                                        |
 |---------------|--------------------------------------------------------------------|
-| **Convex**    | Marginal price must worsen with trade size. Non-convex programs are rejected. |
+| **NAME**      | Must define `const NAME: &str = "...";` — shown on the leaderboard. |
 | **Monotonic** | Larger input must produce larger output.                           |
 | **< 100k CU** | Must execute within the compute unit limit.                       |
 
@@ -134,6 +134,9 @@ Start with `programs/starter/` — a constant-product AMM with 500 bps fees. The
 
 ```rust
 use pinocchio::{account_info::AccountInfo, entrypoint, pubkey::Pubkey, ProgramResult};
+
+/// Required: displayed on the leaderboard.
+const NAME: &str = "My Strategy";
 
 const STORAGE_SIZE: usize = 1024;
 
@@ -158,6 +161,9 @@ pub fn process_instruction(
             unsafe { pinocchio::syscalls::sol_set_return_data(output.to_le_bytes().as_ptr(), 8); }
         }
         2 => {      // afterSwap — update storage here if needed
+        }
+        3 => unsafe {  // Return strategy name for leaderboard
+            pinocchio::syscalls::sol_set_return_data(NAME.as_ptr(), NAME.len() as u64);
         }
         _ => {}
     }

--- a/programs/starter/src/lib.rs
+++ b/programs/starter/src/lib.rs
@@ -38,6 +38,10 @@ pub fn process_instruction(
         2 => {
             // No storage updates needed for basic CFMM
         }
+        // tag 3 = get_name (for leaderboard display)
+        3 => unsafe {
+            pinocchio::syscalls::sol_set_return_data(NAME.as_ptr(), NAME.len() as u64);
+        },
         _ => {}
     }
 

--- a/starter.rs
+++ b/starter.rs
@@ -38,6 +38,10 @@ pub fn process_instruction(
         2 => {
             // No storage updates needed for basic CFMM
         }
+        // tag 3 = get_name (for leaderboard display)
+        3 => unsafe {
+            pinocchio::syscalls::sol_set_return_data(NAME.as_ptr(), NAME.len() as u64);
+        }
         _ => {}
     }
 


### PR DESCRIPTION
## Summary
- Add tag 3 (get_name) handler to `starter.rs` and `programs/starter/src/lib.rs`
- Add `const NAME` to README example code
- Replace Convex requirement with NAME in requirements table

The web UI requires `const NAME: &str = "..."` for leaderboard display. Without tag 3, submissions show as "Unnamed Strategy".

## Files changed
- `starter.rs` — added tag 3 handler
- `programs/starter/src/lib.rs` — added tag 3 handler
- `README.md` — NAME in example + requirements table

🤖 Generated with [Claude Code](https://claude.com/claude-code)